### PR TITLE
More detailed scan

### DIFF
--- a/Dumplings/Constants.cs
+++ b/Dumplings/Constants.cs
@@ -10,7 +10,7 @@ namespace Dumplings
         /// <summary>
         /// January 09, 2015 Bitcointalk announcement - https://bitcointalk.org/index.php?topic=919116.msg10096718
         /// </summary>
-        public const ulong FirstJoinMarketBlock = 392300;
+        public const ulong FirstJoinMarketBlock = 336861;  // block significantly before first known JoinMarket tx from 2015-05-07
 
         /// <summary>
         /// July 06, 2018 Twitter announcement - https://twitter.com/wasabiwallet/status/1537911130718228480

--- a/Dumplings/Constants.cs
+++ b/Dumplings/Constants.cs
@@ -29,6 +29,13 @@ namespace Dumplings
 
         public const ulong FirstWasabiNoCoordAddressBlock = 610000;
 
+        /// <summary>
+        /// 50 was the minimum input count at the beginning of Wasabi 2. (2022-2024) and with at least 10 equal outputs.. 
+        /// Post-zkSNACKs coordinators are sometimes smaller
+        /// </summary>
+        public const int MinWW2Inputs = 15;
+        public const int MinWW2EqualOutputs = 10;
+
         public static IEnumerable<Script> WasabiCoordScripts = new Script[]
         {
             BitcoinAddress.Create("bc1qs604c7jv6amk4cxqlnvuxv26hv3e48cds4m0ew", Network.Main).ScriptPubKey,

--- a/Dumplings/Constants.cs
+++ b/Dumplings/Constants.cs
@@ -40,10 +40,22 @@ namespace Dumplings
 
         public static IEnumerable<Money> SamouraiPools = new Money[]
         {
-            Money.Coins(0.001m),
-            Money.Coins(0.01m),
-            Money.Coins(0.05m),
-            Money.Coins(0.5m)
+            Money.Coins(0.001m), // Samourai pools
+            Money.Coins(0.01m),  // Samourai pools
+            Money.Coins(0.05m),  // Samourai pools
+            Money.Coins(0.5m),   // Samourai pools
+            Money.Coins(0.25m),  // Ashigaru pools  
+            Money.Coins(0.025m)  // Ashigaru pools  
+       
+        };
+
+	 public static readonly uint256[] AshigaruSeedTxIds = new[]  
+        {
+            // 0.025 BTC pool genesis / very first mix
+            uint256.Parse("737a867727db9a2c981ad622f2fa14b021ce8b1066a001e34fb793f8da833155"),
+
+            // 0.25 BTC pool genesis / very first mix
+            uint256.Parse("7784df1182ab86ee33577b75109bb0f7c5622b9fb91df24b65ab2ab01b27dffa")
         };
     }
 }

--- a/Dumplings/Rpc/RpcParser.cs
+++ b/Dumplings/Rpc/RpcParser.cs
@@ -24,6 +24,7 @@ namespace Dumplings.Rpc
                 "witness_v0_keyhash" => RpcPubkeyType.TxWitnessV0Keyhash,
                 "witness_v0_scripthash" => RpcPubkeyType.TxWitnessV0Scripthash,
                 "witness_unknown" => RpcPubkeyType.TxWitnessUnknown,
+                "witness_v1_taproot" => RpcPubkeyType.TxWitnessV1Taproot,
                 _ => RpcPubkeyType.Unknown
             };
         }
@@ -53,6 +54,10 @@ namespace Dumplings.Rpc
             if (scriptPubKey.IsScriptType(ScriptType.P2WSH))
             {
                 return RpcPubkeyType.TxWitnessV0Scripthash;
+            }
+            if (scriptPubKey.IsScriptType(ScriptType.Taproot))
+            {
+                return RpcPubkeyType.TxWitnessV1Taproot;
             }
             if (scriptPubKey.IsScriptType(ScriptType.Witness))
             {

--- a/Dumplings/Rpc/RpcParser.cs
+++ b/Dumplings/Rpc/RpcParser.cs
@@ -113,7 +113,8 @@ namespace Dumplings.Rpc
                             prevOutput: new VerboseOutputInfo(
                                 value: Money.Coins(txinJson.GetProperty("prevout").GetProperty("value").GetDecimal()),
                                 scriptPubKey: Script.FromHex(txinJson.GetProperty("prevout").GetProperty("scriptPubKey").GetProperty("hex").GetString()),
-                                pubkeyType: txinJson.GetProperty("prevout").GetProperty("scriptPubKey").GetProperty("type").GetString())
+                                pubkeyType: txinJson.GetProperty("prevout").GetProperty("scriptPubKey").GetProperty("type").GetString()),
+                            sequence: txinJson.GetProperty("sequence").GetUInt32()
                         );
                     }
 

--- a/Dumplings/Rpc/RpcPubkeyType.cs
+++ b/Dumplings/Rpc/RpcPubkeyType.cs
@@ -11,6 +11,7 @@ namespace Dumplings.Rpc
         TxNullData,
         TxWitnessV0Keyhash,
         TxWitnessV0Scripthash,
+        TxWitnessV1Taproot,
         TxWitnessUnknown,
     }
 }

--- a/Dumplings/Rpc/VerboseInputInfo.cs
+++ b/Dumplings/Rpc/VerboseInputInfo.cs
@@ -10,15 +10,18 @@ namespace Dumplings.Rpc
             Coinbase = coinbase;
         }
 
-        public VerboseInputInfo(OutPoint outPoint, VerboseOutputInfo prevOutput)
+        public VerboseInputInfo(OutPoint outPoint, VerboseOutputInfo prevOutput, uint sequence)
         {
             OutPoint = outPoint;
             PrevOutput = prevOutput;
+            Sequence = sequence;
         }
 
         public OutPoint OutPoint { get; }
 
         public VerboseOutputInfo PrevOutput { get; }
+
+        public uint Sequence { get; }
 
         public string Coinbase { get; }
 
@@ -31,7 +34,7 @@ namespace Dumplings.Rpc
                 return $"coinbase{Separator}{Coinbase}";
             }
 
-            return $"{OutPoint.Hash}{Separator}{OutPoint.N}{Separator}{PrevOutput}";
+            return $"{OutPoint.Hash}{Separator}{OutPoint.N}{Separator}{PrevOutput}{Separator}{Sequence}";
         }
 
         internal static VerboseInputInfo FromString(string x)
@@ -47,7 +50,12 @@ namespace Dumplings.Rpc
             var n = uint.Parse(parts[1]);
             var po = parts[2] is null ? null : VerboseOutputInfo.FromString(parts[2]);
 
-            return new VerboseInputInfo(new OutPoint(hash, n), po);
+            var seq = 0u;
+            if (parts.Length > 3 && parts[3] is null) {
+                seq = uint.Parse(parts[3]);
+            }
+
+            return new VerboseInputInfo(new OutPoint(hash, n), po, seq);
         }
     }
 }

--- a/Dumplings/Rpc/VerboseTransactionInfo.cs
+++ b/Dumplings/Rpc/VerboseTransactionInfo.cs
@@ -82,7 +82,7 @@ namespace Dumplings.Rpc
             var outputCount = outputs.Length;
             var inputCount = inputs.Length;
             return isNativeSegwitOnly
-                    && inputCount >= 50 // 50 was the minimum input count at the beginning of Wasabi 2.
+                    && inputCount >= Constants.MinWW2Inputs 
                     && inputValues.SequenceEqual(inputValues.OrderByDescending(x => x)) // Inputs are ordered descending.
                     && outputValues.SequenceEqual(outputValues.OrderByDescending(x => x)) // Outputs are ordered descending.
                     && outputValues.Count(x => Scanner.Wasabi2Denominations.Contains(x.Satoshi)) > outputCount * 0.8; // Most of the outputs contains the denomination.

--- a/Dumplings/Scanning/Scanner.cs
+++ b/Dumplings/Scanning/Scanner.cs
@@ -129,7 +129,7 @@ namespace Dumplings.Scanning
                             {
                                 isWasabi2Cj =
                                     tx.Inputs.All(x => x.PrevOutput.ScriptPubKey.IsScriptType(ScriptType.P2WPKH) || x.PrevOutput.ScriptPubKey.IsScriptType(ScriptType.Taproot))
-                                    && inputCount >= 50 // 50 was the minimum input count at the beginning of Wasabi 2.
+                                    && inputCount >= 20 // 50 was the minimum input count at the beginning of Wasabi 2.
                                     && inputValues.SequenceEqual(inputValues.OrderByDescending(x => x)) // Inputs are ordered descending.
                                     && outputValues.SequenceEqual(outputValues.OrderByDescending(x => x)) // Outputs are ordered descending.
                                     && outputValues.Count(x => Wasabi2Denominations.Contains(x.Satoshi)) > outputCount * 0.8; // Most of the outputs contains the denomination.

--- a/Dumplings/Scanning/Scanner.cs
+++ b/Dumplings/Scanning/Scanner.cs
@@ -279,7 +279,7 @@ namespace Dumplings.Scanning
                             var tx = await Rpc.GetRawTransactionAsync(i.PrevOut.Hash).ConfigureAwait(false);
                             var o = tx.Outputs[i.PrevOut.N];
                             var voi = new VerboseOutputInfo(o.Value, o.ScriptPubKey);
-                            var vii = new VerboseInputInfo(i.PrevOut, voi);
+                            var vii = new VerboseInputInfo(i.PrevOut, voi, i.Sequence);
                             verboseInputs.Add(vii);
                         }
 

--- a/Dumplings/Scanning/Scanner.cs
+++ b/Dumplings/Scanning/Scanner.cs
@@ -129,7 +129,7 @@ namespace Dumplings.Scanning
                             {
                                 isWasabi2Cj =
                                     tx.Inputs.All(x => x.PrevOutput.ScriptPubKey.IsScriptType(ScriptType.P2WPKH) || x.PrevOutput.ScriptPubKey.IsScriptType(ScriptType.Taproot))
-                                    && inputCount >= 20 // 50 was the minimum input count at the beginning of Wasabi 2.
+                                    && inputCount >= Constants.MinWW2Inputs 
                                     && inputValues.SequenceEqual(inputValues.OrderByDescending(x => x)) // Inputs are ordered descending.
                                     && outputValues.SequenceEqual(outputValues.OrderByDescending(x => x)) // Outputs are ordered descending.
                                     && outputValues.Count(x => Wasabi2Denominations.Contains(x.Satoshi)) > outputCount * 0.8; // Most of the outputs contains the denomination.
@@ -148,7 +148,7 @@ namespace Dumplings.Scanning
                                     var uniqueOutputCount = tx.GetIndistinguishableOutputs(includeSingle: true).Count(x => x.count == 1);
                                     isWasabiCj =
                                         isNativeSegwitOnly
-                                        && mostFrequentEqualOutputCount >= 10 // At least 10 equal outputs.
+                                        && mostFrequentEqualOutputCount >= Constants.MinWW2EqualOutputs 
                                         && inputCount >= mostFrequentEqualOutputCount // More inptuts than most frequent equal outputs.
                                         && mostFrequentEqualOutputValue.Almost(Constants.ApproximateWasabiBaseDenomination, Constants.WasabiBaseDenominationPrecision) // The most frequent equal outputs must be almost the base denomination.
                                         && uniqueOutputCount >= 2; // It's very likely there's at least one change and at least one coord output those have unique values.

--- a/Dumplings/Scanning/Scanner.cs
+++ b/Dumplings/Scanning/Scanner.cs
@@ -62,7 +62,7 @@ namespace Dumplings.Scanning
 
             var opreturnTransactionCache = new MemoryCache(new MemoryCacheOptions() { SizeLimit = 100000 });
 
-            ulong startingHeight = Constants.FirstWasabiBlock;
+            ulong startingHeight = Constants.FirstJoinMarketBlock; 
             ulong height = startingHeight;
             if (File.Exists(LastProcessedBlockHeightPath))
             {
@@ -183,7 +183,7 @@ namespace Dumplings.Scanning
                             {
                                 isOtherCj =
                                     indistinguishableOutputs.Length == 1 // If it isn't then it'd be likely a multidenomination CJ, which only Wasabi does.
-                                    && mostFrequentEqualOutputCount == outputCount - mostFrequentEqualOutputCount // Rarely it isn't, but it helps filtering out false positives.
+                                    && (mostFrequentEqualOutputCount == outputCount - mostFrequentEqualOutputCount || mostFrequentEqualOutputCount == outputCount - mostFrequentEqualOutputCount + 1) // Rarely it isn't, but it helps filtering out false positives. +1 condition is for case when taker make sweep tx with no change
                                     && outputs.Select(x => x.ScriptPubKey).Distinct().Count() >= mostFrequentEqualOutputCount // Otherwise more participants would be single actors which makes no sense.
                                     && inputs.Select(x => x.ScriptPubKey).Distinct().Count() >= mostFrequentEqualOutputCount // Otherwise more participants would be single actors which makes no sense.
                                     && inputValues.Max() <= mostFrequentEqualOutputValue + outputValues.Where(x => x != mostFrequentEqualOutputValue).Max() - Money.Coins(0.0001m); // I don't want to run expensive subset sum, so this is a shortcut to at least filter out false positives.


### PR DESCRIPTION
* Add Ashigaru scanning
* Decrease minimum considered coinjoin size for WW2 to 15 inputs
* Add detection of taproot scripts
* Add JoinMarket scanning